### PR TITLE
Fixed texinfo5 strictness bugs

### DIFF
--- a/bfd/doc/bfd.texinfo
+++ b/bfd/doc/bfd.texinfo
@@ -322,7 +322,7 @@ All of BFD lives in one directory.
 @printindex cp
 
 @tex
-% I think something like @colophon should be in texinfo.  In the
+% I think something like @@colophon should be in texinfo.  In the
 % meantime:
 \long\def\colophon{\hbox to0pt{}\vfill
 \centerline{The body of this manual is set in}
@@ -333,7 +333,7 @@ All of BFD lives in one directory.
 \centerline{{\sl\fontname\tensl\/}}
 \centerline{are used for emphasis.}\vfill}
 \page\colophon
-% Blame: doc@cygnus.com, 28mar91.
+% Blame: doc@@cygnus.com, 28mar91.
 @end tex
 
 @bye

--- a/binutils/doc/binutils.texi
+++ b/binutils/doc/binutils.texi
@@ -4379,7 +4379,7 @@ equivalent. At least one of the @option{--output-mach},
 
 @table @env
 
-@itemx --input-mach=@var{machine}
+@item --input-mach=@var{machine}
 Set the matching input ELF machine type to @var{machine}.  If
 @option{--input-mach} isn't specified, it will match any ELF
 machine types.
@@ -4387,21 +4387,21 @@ machine types.
 The supported ELF machine types are, @var{L1OM}, @var{K1OM} and
 @var{x86-64}.
 
-@itemx --output-mach=@var{machine}
+@item --output-mach=@var{machine}
 Change the ELF machine type in the ELF header to @var{machine}.  The
 supported ELF machine types are the same as @option{--input-mach}.
 
-@itemx --input-type=@var{type}
+@item --input-type=@var{type}
 Set the matching input ELF file type to @var{type}.  If
 @option{--input-type} isn't specified, it will match any ELF file types.
 
 The supported ELF file types are, @var{rel}, @var{exec} and @var{dyn}.
 
-@itemx --output-type=@var{type}
+@item --output-type=@var{type}
 Change the ELF file type in the ELF header to @var{type}.  The
 supported ELF types are the same as @option{--input-type}.
 
-@itemx --input-osabi=@var{osabi}
+@item --input-osabi=@var{osabi}
 Set the matching input ELF file OSABI to @var{osabi}.  If
 @option{--input-osabi} isn't specified, it will match any ELF OSABIs.
 
@@ -4411,7 +4411,7 @@ The supported ELF OSABIs are, @var{none}, @var{HPUX}, @var{NetBSD},
 @var{FreeBSD}, @var{TRU64}, @var{Modesto}, @var{OpenBSD}, @var{OpenVMS},
 @var{NSK}, @var{AROS} and @var{FenixOS}.
 
-@itemx --output-osabi=@var{osabi}
+@item --output-osabi=@var{osabi}
 Change the ELF OSABI in the ELF header to @var{osabi}.  The
 supported ELF OSABI are the same as @option{--input-osabi}.
 

--- a/gas/doc/c-arc.texi
+++ b/gas/doc/c-arc.texi
@@ -220,7 +220,7 @@ The extension instructions are not macros.  The assembler creates
 encodings for use of these instructions according to the specification
 by the user.  The parameters are:
 
-@table 
+@table @code
 @item @var{name}
 Name of the extension instruction 
 

--- a/gas/doc/c-arc.texi
+++ b/gas/doc/c-arc.texi
@@ -1,4 +1,4 @@
-@c Copyright 2000, 2001, 2005, 2006, 2007, 2011 Free Software Foundation, Inc.
+@c Copyright 2000-2013 Free Software Foundation, Inc.
 @c This is part of the GAS manual.
 @c For copying conditions, see the file as.texinfo.
 
@@ -220,7 +220,7 @@ The extension instructions are not macros.  The assembler creates
 encodings for use of these instructions according to the specification
 by the user.  The parameters are:
 
-@table @bullet
+@table 
 @item @var{name}
 Name of the extension instruction 
 

--- a/gas/doc/c-arm.texi
+++ b/gas/doc/c-arm.texi
@@ -1,5 +1,4 @@
-@c Copyright 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
-@c 2006, 2007, 2008, 2009, 2010, 2011  Free Software Foundation, Inc.
+@c Copyright 1996-2013 Free Software Foundation, Inc.
 @c This is part of the GAS manual.
 @c For copying conditions, see the file as.texinfo.
 
@@ -388,29 +387,29 @@ ARM and THUMB instructions had their own, separate syntaxes.  The new,
 @code{unified} syntax, which can be selected via the @code{.syntax}
 directive, and has the following main features:
 
-@table @bullet
-@item
+@table
+@item 1
 Immediate operands do not require a @code{#} prefix.
 
-@item
+@item 2
 The @code{IT} instruction may appear, and if it does it is validated
 against subsequent conditional affixes.  In ARM mode it does not
 generate machine code, in THUMB mode it does.
 
-@item
+@item 3
 For ARM instructions the conditional affixes always appear at the end
 of the instruction.  For THUMB instructions conditional affixes can be
 used, but only inside the scope of an @code{IT} instruction.
 
-@item
+@item 4
 All of the instructions new to the V6T2 architecture (and later) are
 available.  (Only a few such instructions can be written in the
 @code{divided} syntax).
 
-@item
+@item 5
 The @code{.N} and @code{.W} suffixes are recognized and honored.
 
-@item
+@item 6
 All instructions set the flags if and only if they have an @code{s}
 affix.
 @end table
@@ -448,28 +447,6 @@ Either @samp{#} or @samp{$} can be used to indicate immediate operands.
 @cindex ARM register names
 @cindex register names, ARM
 *TODO* Explain about ARM register naming, and the predefined names.
-
-@node ARM-Neon-Alignment
-@subsection NEON Alignment Specifiers
-
-@cindex alignment for NEON instructions
-Some NEON load/store instructions allow an optional address
-alignment qualifier.
-The ARM documentation specifies that this is indicated by
-@samp{@@ @var{align}}. However GAS already interprets
-the @samp{@@} character as a "line comment" start,
-so @samp{: @var{align}} is used instead.  For example:
-
-@smallexample
-        vld1.8 @{q0@}, [r0, :128]
-@end smallexample
-
-@node ARM Floating Point
-@section Floating Point
-
-@cindex floating point, ARM (@sc{ieee})
-@cindex ARM floating point (@sc{ieee})
-The ARM family uses @sc{ieee} floating-point numbers.
 
 @node ARM-Relocations
 @subsection ARM relocation generation
@@ -516,6 +493,28 @@ respectively.  For example to load the 32-bit address of foo into r0:
         MOVW r0, #:lower16:foo
         MOVT r0, #:upper16:foo
 @end smallexample
+
+@node ARM-Neon-Alignment
+@subsection NEON Alignment Specifiers
+
+@cindex alignment for NEON instructions
+Some NEON load/store instructions allow an optional address
+alignment qualifier.
+The ARM documentation specifies that this is indicated by
+@samp{@@ @var{align}}. However GAS already interprets
+the @samp{@@} character as a "line comment" start,
+so @samp{: @var{align}} is used instead.  For example:
+
+@smallexample
+        vld1.8 @{q0@}, [r0, :128]
+@end smallexample
+
+@node ARM Floating Point
+@section Floating Point
+
+@cindex floating point, ARM (@sc{ieee})
+@cindex ARM floating point (@sc{ieee})
+The ARM family uses @sc{ieee} floating-point numbers.
 
 @node ARM Directives
 @section ARM Machine Directives

--- a/gas/doc/c-arm.texi
+++ b/gas/doc/c-arm.texi
@@ -387,7 +387,7 @@ ARM and THUMB instructions had their own, separate syntaxes.  The new,
 @code{unified} syntax, which can be selected via the @code{.syntax}
 directive, and has the following main features:
 
-@table
+@table @code
 @item 1
 Immediate operands do not require a @code{#} prefix.
 

--- a/gas/doc/c-cr16.texi
+++ b/gas/doc/c-cr16.texi
@@ -1,4 +1,4 @@
-@c Copyright 2007, 2008, 2011 Free Software Foundation, Inc.
+@c Copyright 2007-2013 Free Software Foundation, Inc.
 @c This is part of the GAS manual.
 @c For copying conditions, see the file as.texinfo.
 

--- a/gas/doc/c-cr16.texi
+++ b/gas/doc/c-cr16.texi
@@ -46,23 +46,23 @@ CR16 target operand qualifiers and its size (in bits):
 @table @samp
 @item Immediate Operand
 - s ---- 4 bits
-@item 
+@item 1
 - m ---- 16 bits, for movb and movw instructions.
-@item 
+@item 2
 - m ---- 20 bits, movd instructions.
-@item 
+@item 3
 - l ---- 32 bits
 
 @item Absolute Operand
 - s ---- Illegal specifier for this operand.
-@item  
+@item 4
 - m ---- 20 bits, movd instructions.
 
 @item Displacement Operand
 - s ---- 8 bits
-@item
+@item 5
 - m ---- 16 bits
-@item 
+@item 6
 - l ---- 24 bits
 @end table
 

--- a/gas/doc/c-mips.texi
+++ b/gas/doc/c-mips.texi
@@ -234,9 +234,9 @@ the @samp{mad} and @samp{madu} instruction, and to not schedule @samp{nop}
 instructions around accesses to the @samp{HI} and @samp{LO} registers.
 @samp{-no-m4650} turns off this option.
 
-@itemx -m3900
+@item -m3900
 @itemx -no-m3900
-@itemx -m4100
+@item -m4100
 @itemx -no-m4100
 For each option @samp{-m@var{nnnn}}, generate code for the MIPS
 @sc{r@var{nnnn}} chip.  This tells the assembler to accept instructions

--- a/gas/doc/c-score.texi
+++ b/gas/doc/c-score.texi
@@ -37,7 +37,7 @@ implicitly with the @code{gp} register. The default value is 8.
 @item -EB
 Assemble code for a big-endian cpu
 
-@itemx -EL
+@item -EL
 Assemble code for a little-endian cpu
 
 @item -FIXDD 
@@ -49,13 +49,13 @@ Assemble code for no warning message for fix data dependency
 @item -SCORE5
 Assemble code for target is SCORE5
 
-@itemx -SCORE5U
+@item -SCORE5U
 Assemble code for target is SCORE5U
 
-@itemx -SCORE7
+@item -SCORE7
 Assemble code for target is SCORE7, this is default setting
 
-@itemx -SCORE3
+@item -SCORE3
 Assemble code for target is SCORE3
 
 @item -march=score7

--- a/gas/doc/c-tic54x.texi
+++ b/gas/doc/c-tic54x.texi
@@ -345,7 +345,7 @@ Assign @var{name} the string @var{string}.  String replacement is
 performed on @var{string} before assignment.
 
 @cindex @code{eval} directive, TIC54X
-@itemx .eval @var{string}, @var{name}
+@item .eval @var{string}, @var{name}
 Evaluate the contents of string @var{string} and assign the result as a
 string to the subsym @var{name}.  String replacement is performed on
 @var{string} before assignment. 

--- a/gas/doc/c-tic54x.texi
+++ b/gas/doc/c-tic54x.texi
@@ -1,4 +1,4 @@
-@c Copyright 2000, 2002, 2003, 2006, 2011 Free Software Foundation, Inc.
+@c Copyright 2000-2013 Free Software Foundation, Inc.
 @c This is part of the GAS manual.
 @c For copying conditions, see the file as.texinfo.
 @c TI TMS320C54X description by Timothy Wall, twall@cygnus.com
@@ -109,7 +109,7 @@ In this example, x is replaced with SYM2; SYM2 is replaced with SYM1, and SYM1
 is replaced with x.  At this point, x has already been encountered
 and the substitution stops.
 
-@smallexample @code
+@smallexample
  .asg   "x",SYM1 
  .asg   "SYM1",SYM2
  .asg   "SYM2",x
@@ -126,14 +126,14 @@ Substitution may be forced in situations where replacement might be
 ambiguous by placing colons on either side of the subsym.  The following
 code: 
 
-@smallexample @code
+@smallexample
  .eval  "10",x
 LAB:X:  add     #x, a
 @end smallexample
 
 When assembled becomes:
 
-@smallexample @code
+@smallexample
 LAB10  add     #10, a
 @end smallexample
 
@@ -309,7 +309,7 @@ The @code{LDX} pseudo-op is provided for loading the extended addressing bits
 of a label or address.  For example, if an address @code{_label} resides
 in extended program memory, the value of @code{_label} may be loaded as
 follows:
-@smallexample @code
+@smallexample
  ldx     #_label,16,a    ; loads extended bits of _label
  or      #_label,a       ; loads lower 16 bits of _label
  bacc    a               ; full address is in accumulator A

--- a/ld/ld.texinfo
+++ b/ld/ld.texinfo
@@ -7856,7 +7856,7 @@ If you have more than one @code{SECT} statement for the same
 @printindex cp
 
 @tex
-% I think something like @colophon should be in texinfo.  In the
+% I think something like @@colophon should be in texinfo.  In the
 % meantime:
 \long\def\colophon{\hbox to0pt{}\vfill
 \centerline{The body of this manual is set in}
@@ -7867,7 +7867,7 @@ If you have more than one @code{SECT} statement for the same
 \centerline{{\sl\fontname\tensl\/}}
 \centerline{are used for emphasis.}\vfill}
 \page\colophon
-% Blame: doc@cygnus.com, 28mar91.
+% Blame: doc@@cygnus.com, 28mar91.
 @end tex
 
 @bye


### PR DESCRIPTION
This version of binutils will not build on machines with texinfo 5 or above. This patch fixes this by making the texi files conform to the stricter syntax.
